### PR TITLE
Added `lookupLT` + tests to Map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^20.8.10",
+        "fast-check": "^3.15.1",
         "typedoc": "^0.25.4",
         "typescript": "^5.2.2"
       }
@@ -42,6 +43,28 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.15.1.tgz",
+      "integrity": "sha512-GutOXZ+SCxGaFWfHe0Pbeq8PrkpGtPxA9/hdkI3s9YzqeMlrq5RdJ+QfYZ/S93jMX+tAyqgW0z5c9ppD+vkGUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/jsonc-parser": {
@@ -82,6 +105,22 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/shiki": {
       "version": "0.14.6",
@@ -179,6 +218,15 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "fast-check": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.15.1.tgz",
+      "integrity": "sha512-GutOXZ+SCxGaFWfHe0Pbeq8PrkpGtPxA9/hdkI3s9YzqeMlrq5RdJ+QfYZ/S93jMX+tAyqgW0z5c9ppD+vkGUw==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^6.0.0"
+      }
+    },
     "jsonc-parser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
@@ -205,6 +253,12 @@
       "requires": {
         "brace-expansion": "^2.0.1"
       }
+    },
+    "pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "dev": true
     },
     "shiki": {
       "version": "0.14.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^20.8.10",
+    "fast-check": "^3.15.1",
     "typedoc": "^0.25.4",
     "typescript": "^5.2.2"
   },

--- a/src/Prelude/Runtime/AvlTree.ts
+++ b/src/Prelude/Runtime/AvlTree.ts
@@ -134,6 +134,17 @@ export function findMin<K>(node: Node<K>): Node<K> {
   return node;
 }
 
+export function findMax<K>(node: Node<K>): Node<K> {
+  if (node === null) {
+    return null;
+  }
+  while (node.right !== null) {
+    node = node.right;
+  }
+
+  return node;
+}
+
 export function remove<K>(ordDict: Ord<K>, key: K, node: Node<K>): Node<K> {
   function go(k: K, n: Node<K>): Node<K> {
     if (n === null) {
@@ -331,4 +342,34 @@ export function lookup<K>(
   }
 
   return undefined;
+}
+
+export function lookupLT<K>(
+  ordDict: Ord<K>,
+  k: Readonly<K>,
+  node: Node<K>,
+): undefined | K {
+  let ans: undefined | K = undefined;
+
+  while (node !== null) {
+    switch (ordDict.compare(k, node.element)) {
+      case "EQ":
+        node = findMax(node.left);
+        if (node === null) {
+          return ans;
+        }
+        ans = node.element;
+        return ans;
+
+      case "LT":
+        node = node.left;
+        break;
+      case "GT":
+        ans = node.element;
+        node = node.right;
+        break;
+    }
+  }
+
+  return ans;
 }

--- a/src/Prelude/Runtime/Map.ts
+++ b/src/Prelude/Runtime/Map.ts
@@ -130,6 +130,29 @@ export function lookup<K, V>(
 }
 
 /**
+ * {@link lookupLT} looks up the largest value in the {@link Map} for which its
+ * corresponding key is strictly smaller than the given key returning `Just` if
+ * such a value exists or `Nothing` otherwise.
+ *
+ * Complexity: `O(log n)`
+ */
+export function lookupLT<K, V>(
+  ordDict: Ord<K>,
+  key: K,
+  map: Readonly<Map<K, V>>,
+): Maybe<V> {
+  const lkup: undefined | [K, V] = PAvlTree.lookupLT(ordOnFst(ordDict), [
+    key,
+    null as V,
+  ], map.tree);
+  if (lkup === undefined) {
+    return { name: "Nothing" };
+  } else {
+    return { name: "Just", fields: lkup[1] };
+  }
+}
+
+/**
  * Returns a list of key value pairs in ascending order
  *
  * Complexity: `O(n)`
@@ -140,6 +163,9 @@ export function toList<K, V>(map: Readonly<Map<K, V>>): [K, V][] {
 
 /**
  * Checks the invariants of the internal AVL tree.
+ *
+ * @throws {@link Error}
+ * This exception is thrown if the invariants are violated
  *
  * @internal
  */

--- a/src/Tests/MapModel-test.ts
+++ b/src/Tests/MapModel-test.ts
@@ -1,0 +1,253 @@
+// This module provides model property based testing for maps i.e., we have an
+// "idealized" _model_ of a map, and verify that an operation on our _real_ map
+// "commutes" with the same operation on the model of our idealized map.
+//
+// In particular, the idealized model of our real map will be JS' actual
+// builtin Map for strings (since JS' builtin map's notion of equality for keys
+// coincides with ours for the string type).
+//
+// Most of the code here follows from the documentation in [1].
+//
+// References:
+//  [1]: https://fast-check.dev/docs/advanced/model-based-testing/
+import { describe, it } from "node:test";
+
+import * as assert from "node:assert/strict";
+import * as Prelude from "../Prelude/Prelude.js";
+import * as PMap from "../Prelude/Runtime/Map.js";
+import * as fc from "fast-check";
+
+type Model = Map<Prelude.Text, Prelude.Text>;
+type Real = PMap.Map<Prelude.Text, Prelude.Text>;
+
+/**
+ * {@link InsertCommand} a command for inserting a key value pair
+ */
+class InsertCommand implements fc.Command<Model, Real> {
+  #k: Prelude.Text;
+  #v: Prelude.Text;
+
+  constructor(k: Readonly<Prelude.Text>, v: Readonly<Prelude.Text>) {
+    this.#k = k;
+    this.#v = v;
+  }
+
+  check(_m: Readonly<Model>) {
+    return true;
+  }
+
+  run(m: Model, r: Real) {
+    m.set(this.#k, this.#v);
+    PMap.insert(Prelude.ordText, this.#k, this.#v, r);
+
+    PMap.checkInvariants(Prelude.ordText, r);
+  }
+
+  toString() {
+    return `insert(${JSON.stringify(this.#k)}, ${JSON.stringify(this.#v)})`;
+  }
+}
+
+/**
+ * {@link LookupCommand} a command for looking up a key
+ */
+class LookupCommand implements fc.Command<Model, Real> {
+  #k: Prelude.Text;
+
+  constructor(k: Readonly<Prelude.Text>) {
+    this.#k = k;
+  }
+
+  check(_m: Readonly<Model>) {
+    return true;
+  }
+
+  run(m: Model, r: Real) {
+    const modelV = m.get(this.#k);
+    const rV = PMap.lookup(Prelude.ordText, this.#k, r);
+
+    PMap.checkInvariants(Prelude.ordText, r);
+
+    if (modelV === undefined && rV.name === "Nothing") {
+      return;
+    } else if (
+      (modelV !== undefined && rV.name === "Just") &&
+      (modelV === rV.fields)
+    ) {
+      return;
+    } else {
+      assert.fail(
+        `lookup(${this.#k}): failed. Model has \`${modelV}\` but implementation has \`${
+          JSON.stringify(rV)
+        }\``,
+      );
+    }
+  }
+
+  toString() {
+    return `lookup(${JSON.stringify(this.#k)})`;
+  }
+}
+
+/**
+ * {@link LookupLTCommand} a command for looking up the largest key which is
+ * strictly less than the provided key
+ */
+class LookupLTCommand implements fc.Command<Model, Real> {
+  #k: Prelude.Text;
+
+  constructor(k: Readonly<Prelude.Text>) {
+    this.#k = k;
+  }
+
+  check(_m: Readonly<Model>) {
+    return true;
+  }
+
+  run(m: Model, r: Real) {
+    let answer: [Prelude.Text, Prelude.Text] | undefined = undefined;
+
+    for (const [k, v] of m) {
+      // we only care about elements strictly smaller
+      if (Prelude.ordText.compare(k, this.#k) !== "LT") {
+        continue;
+      }
+
+      if (answer === undefined) {
+        answer = [k, v];
+      } else if (Prelude.ordText.compare(answer[0], k) === "EQ") {
+        assert.fail(`Map has not unique keys invariant violated`);
+      } else if (Prelude.ordText.compare(answer[0], k) === "LT") {
+        // `answer[0]` is strictly smaller than `k`, but recall `k` is
+        // still smaller than this.#k, so `k` is the better solution
+        answer = [k, v];
+      }
+    }
+
+    const modelV = answer === undefined ? undefined : answer[1];
+
+    const rV = PMap.lookupLT(Prelude.ordText, this.#k, r);
+
+    PMap.checkInvariants(Prelude.ordText, r);
+
+    if (modelV === undefined && rV.name === "Nothing") {
+      return;
+    } else if (
+      (modelV !== undefined && rV.name === "Just") &&
+      (modelV === rV.fields)
+    ) {
+      return;
+    } else {
+      assert.fail(
+        `lookupLT(${this.#k}): failed. Model has \`${modelV}\` but implementation has \`${
+          JSON.stringify(rV)
+        }\``,
+      );
+    }
+  }
+
+  toString() {
+    return `lookupLT(${JSON.stringify(this.#k)})`;
+  }
+}
+
+/**
+ * {@link RemoveCommand} a command for looking up a key
+ */
+class RemoveCommand implements fc.Command<Model, Real> {
+  #k: Prelude.Text;
+
+  constructor(k: Readonly<Prelude.Text>) {
+    this.#k = k;
+  }
+
+  check(_m: Readonly<Model>) {
+    return true;
+  }
+
+  run(m: Model, r: Real) {
+    m.delete(this.#k);
+
+    PMap.remove(Prelude.ordText, this.#k, r);
+
+    PMap.checkInvariants(Prelude.ordText, r);
+  }
+
+  toString() {
+    return `remove(${JSON.stringify(this.#k)})`;
+  }
+}
+
+/**
+ * {@link LengthCommand} a command for getting the length
+ */
+class LengthCommand implements fc.Command<Model, Real> {
+  constructor() {}
+
+  check(_m: Readonly<Model>) {
+    return true;
+  }
+
+  run(m: Model, r: Real) {
+    PMap.checkInvariants(Prelude.ordText, r);
+    assert.equal(r.length, m.size);
+  }
+
+  toString() {
+    return `length`;
+  }
+}
+
+describe(`Map<Prelude.Text,Prelude.Text> model tests`, () => {
+  it(`General tests`, () => {
+    const allCommands = [
+      fc.tuple(fc.string(), fc.string()).map(([k, v]) =>
+        new InsertCommand(k, v)
+      ),
+      fc.string().map((str) => new LookupCommand(str)),
+      fc.string().map((str) => new LookupLTCommand(str)),
+      fc.string().map((str) => new RemoveCommand(str)),
+      fc.constant(new LengthCommand()),
+    ];
+    fc.assert(
+      fc.property(fc.commands(allCommands, {}), (cmds) => {
+        function s() {
+          return { model: new Map(), real: new PMap.Map() };
+        }
+        fc.modelRun(s, cmds);
+      }),
+      {
+        numRuns: 10_000,
+      },
+    );
+  });
+
+  const smallStringOptions = { minLength: 0, maxLength: 4 };
+
+  // We have some "small string" tests s.t. we can be almost certain that the
+  it(`Small ASCII string tests`, () => {
+    const allCommands = [
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.hexaString(smallStringOptions).map((str) => new LookupCommand(str)),
+      fc.hexaString(smallStringOptions).map((str) => new LookupLTCommand(str)),
+      fc.hexaString(smallStringOptions).map((str) => new RemoveCommand(str)),
+      fc.constant(new LengthCommand()),
+    ];
+    fc.assert(
+      fc.property(
+        fc.commands(allCommands, { maxCommands: 256, size: "max" }),
+        (cmds) => {
+          function s() {
+            return { model: new Map(), real: new PMap.Map() };
+          }
+          fc.modelRun(s, cmds);
+        },
+      ),
+      {
+        numRuns: 10_000,
+      },
+    );
+  });
+});


### PR DESCRIPTION
Adds the `lookupLT` function to `Map`, and uses [model property based testing](https://fast-check.dev/docs/advanced/model-based-testing/)