### PR TITLE
Added `split` function to `Map`

### DIFF
--- a/src/Tests/Map-test.ts
+++ b/src/Tests/Map-test.ts
@@ -41,16 +41,6 @@ export function removeAndCheck<K, V>(ordDict: Ord<K>, k: K, map: Map<K, V>) {
   }
 }
 
-export function checkMapLength<K, V>(map: Map<K, V>, expectedLength: number) {
-  if (map.length !== expectedLength) {
-    throw new Error(
-      `Expected map of length ${expectedLength} but got ${map.length} for map ${
-        JSON.stringify(map.tree)
-      }`,
-    );
-  }
-}
-
 export function randomIntUpToButNotIncluding(max: number) {
   return Math.floor(Math.random() * max);
 }
@@ -59,29 +49,17 @@ describe("Map tests", () => {
   describe("Ascending insertion invariant checks", () => {
     const map: Map<number, number> = new Map();
 
-    checkMapLength(map, 0);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
-    checkMapLength(map, 1);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 1, 1, map);
-    checkMapLength(map, 2);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 2, 2, map);
-    checkMapLength(map, 3);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 3, 3, map);
-    checkMapLength(map, 4);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 4, 4, map);
-    checkMapLength(map, 5);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 5, 5, map);
-    checkMapLength(map, 6);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 6, 6, map);
-    checkMapLength(map, 7);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 7, 7, map);
-    checkMapLength(map, 8);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 8, 8, map);
-    checkMapLength(map, 9);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 9, 9, map);
-    checkMapLength(map, 10);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 10, 10, map);
-    checkMapLength(map, 11);
 
     for (let i = 0; i <= 10; ++i) {
       if (PMap.lookup(Prelude.ordPrimitive, i, map).name === "Nothing") {
@@ -89,8 +67,6 @@ describe("Map tests", () => {
           `${i} not found in the map: ${JSON.stringify(map.tree)}`,
         );
       }
-      // lookups shouldn't change the length
-      checkMapLength(map, 11);
     }
 
     for (let i = 11; i <= 20; ++i) {
@@ -103,29 +79,17 @@ describe("Map tests", () => {
   describe("Descending insertion invariant checks", () => {
     const map: Map<number, number> = new Map();
 
-    checkMapLength(map, 0);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 10, 10, map);
-    checkMapLength(map, 1);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 9, 9, map);
-    checkMapLength(map, 2);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 8, 8, map);
-    checkMapLength(map, 3);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 7, 7, map);
-    checkMapLength(map, 4);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 6, 6, map);
-    checkMapLength(map, 5);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 5, 5, map);
-    checkMapLength(map, 6);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 4, 4, map);
-    checkMapLength(map, 7);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 3, 3, map);
-    checkMapLength(map, 8);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 2, 2, map);
-    checkMapLength(map, 9);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 1, 1, map);
-    checkMapLength(map, 10);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
-    checkMapLength(map, 11);
 
     for (let i = 0; i <= 10; ++i) {
       if (PMap.lookup(Prelude.ordPrimitive, i, map).name === "Nothing") {
@@ -133,7 +97,6 @@ describe("Map tests", () => {
           `${i} not found in the map: ${JSON.stringify(map.tree)}`,
         );
       }
-      checkMapLength(map, 11);
     }
 
     for (let i = 11; i <= 20; ++i) {
@@ -156,29 +119,17 @@ describe("Map tests", () => {
   describe("Assorted insertion invariant checks 1.", () => {
     const map: Map<number, number> = new Map();
 
-    checkMapLength(map, 0);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 9, 9, map);
-    checkMapLength(map, 1);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 7, 7, map);
-    checkMapLength(map, 2);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 8, 8, map);
-    checkMapLength(map, 3);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 10, 10, map);
-    checkMapLength(map, 4);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 5, 5, map);
-    checkMapLength(map, 5);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 1, 1, map);
-    checkMapLength(map, 6);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 6, 6, map);
-    checkMapLength(map, 7);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 3, 3, map);
-    checkMapLength(map, 8);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
-    checkMapLength(map, 9);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 4, 4, map);
-    checkMapLength(map, 10);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 2, 2, map);
-    checkMapLength(map, 11);
 
     for (let i = 0; i <= 10; ++i) {
       if (PMap.lookup(Prelude.ordPrimitive, i, map).name === "Nothing") {
@@ -186,7 +137,6 @@ describe("Map tests", () => {
           `${i} not found in the map: ${JSON.stringify(map.tree)}`,
         );
       }
-      checkMapLength(map, 11);
     }
 
     for (let i = 11; i <= 20; ++i) {
@@ -198,29 +148,17 @@ describe("Map tests", () => {
 
   describe("Assorted insertion invariant checks 2.", () => {
     const map: Map<number, number> = new Map();
-    checkMapLength(map, 0);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 2, 2, map);
-    checkMapLength(map, 1);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 4, 4, map);
-    checkMapLength(map, 2);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
-    checkMapLength(map, 3);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 3, 3, map);
-    checkMapLength(map, 4);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 6, 6, map);
-    checkMapLength(map, 5);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 1, 1, map);
-    checkMapLength(map, 6);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 5, 5, map);
-    checkMapLength(map, 7);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 10, 10, map);
-    checkMapLength(map, 8);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 8, 8, map);
-    checkMapLength(map, 9);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 7, 7, map);
-    checkMapLength(map, 10);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 9, 9, map);
-    checkMapLength(map, 11);
 
     for (let i = 0; i <= 10; ++i) {
       if (PMap.lookup(Prelude.ordPrimitive, i, map).name === "Nothing") {
@@ -228,7 +166,6 @@ describe("Map tests", () => {
           `${i} not found in the map: ${JSON.stringify(map.tree)}`,
         );
       }
-      checkMapLength(map, 11);
     }
 
     for (let i = 11; i <= 20; ++i) {
@@ -304,19 +241,14 @@ describe("Map tests", () => {
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 1, 1, map);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 2, 2, map);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 3, 3, map);
-    checkMapLength(map, 4);
 
     removeAndCheck(Prelude.ordPrimitive, 3, map);
-    checkMapLength(map, 3);
 
     removeAndCheck(Prelude.ordPrimitive, 0, map);
-    checkMapLength(map, 2);
 
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
-    checkMapLength(map, 3);
 
     removeAndCheck(Prelude.ordPrimitive, 2, map);
-    checkMapLength(map, 2);
   });
 
   describe("Small ascending insertion / deletion invariant checks 2.", () => {
@@ -325,17 +257,11 @@ describe("Map tests", () => {
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 3, 3, map);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 2, 2, map);
-    checkMapLength(map, 3);
     removeAndCheck(Prelude.ordPrimitive, 3, map);
-    checkMapLength(map, 2);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 1, 1, map);
-    checkMapLength(map, 3);
     removeAndCheck(Prelude.ordPrimitive, 0, map);
-    checkMapLength(map, 2);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
-    checkMapLength(map, 3);
     removeAndCheck(Prelude.ordPrimitive, 2, map);
-    checkMapLength(map, 2);
   });
 
   describe("Small ascending insertion / deletion invariant checks 3.", () => {
@@ -344,9 +270,7 @@ describe("Map tests", () => {
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 3, 3, map);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 0, 0, map);
     insertAndCheck(Prelude.ordPrimitive, Prelude.eqPrimitive, 2, 2, map);
-    checkMapLength(map, 3);
     removeAndCheck(Prelude.ordPrimitive, 69, map);
-    checkMapLength(map, 3);
   });
 
   describe("Large random insertion/deletion invariant checks 1.", () => {
@@ -385,7 +309,6 @@ describe("Map tests", () => {
           map,
         );
       }
-      checkMapLength(map, Object.keys(insertions).length);
     }
 
     for (const [key, value] of Object.entries(insertions)) {
@@ -402,8 +325,6 @@ describe("Map tests", () => {
         );
       }
     }
-
-    checkMapLength(map, Object.keys(insertions).length);
   });
 
   describe("Large random insertion/deletion invariant checks 2.", () => {
@@ -438,7 +359,6 @@ describe("Map tests", () => {
           map,
         );
       }
-      checkMapLength(map, Object.keys(insertions).length);
     }
 
     for (const [key, value] of Object.entries(insertions)) {
@@ -455,8 +375,6 @@ describe("Map tests", () => {
         );
       }
     }
-
-    checkMapLength(map, Object.keys(insertions).length);
   });
 
   describe("toList ascending string tests", () => {

--- a/src/Tests/MapModel-test.ts
+++ b/src/Tests/MapModel-test.ts
@@ -294,7 +294,8 @@ describe(`Map<Prelude.Text,Prelude.Text> model tests`, () => {
 
   const smallStringOptions = { minLength: 0, maxLength: 4 };
 
-  // We have some "small string" tests s.t. we can be almost certain that the
+  // We have some "small string" tests s.t. we can be almost certain that we'll
+  // have "hits" in insertions + deletions
   it(`Small ASCII string tests`, () => {
     const allCommands = [
       fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
@@ -309,7 +310,55 @@ describe(`Map<Prelude.Text,Prelude.Text> model tests`, () => {
     ];
     fc.assert(
       fc.property(
-        fc.commands(allCommands, { maxCommands: 256, size: "max" }),
+        fc.commands(allCommands, { maxCommands: 512, size: "max" }),
+        (cmds) => {
+          function s() {
+            return { model: new Map(), real: new PMap.Map() };
+          }
+          fc.modelRun(s, cmds);
+        },
+      ),
+      {
+        numRuns: 10_000,
+      },
+    );
+  });
+
+  // We make it more likely to generate an insertion so nontrivial maps are
+  // more likely
+  it(`Small ASCII string tests biased with more insertions`, () => {
+    const allCommands = [
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.tuple(fc.hexaString(smallStringOptions), fc.hexaString()).map((
+        [k, v],
+      ) => new InsertCommand(k, v)),
+      fc.hexaString(smallStringOptions).map((str) => new LookupCommand(str)),
+      fc.hexaString(smallStringOptions).map((str) => new LookupLTCommand(str)),
+      fc.hexaString(smallStringOptions).map((str) => new RemoveCommand(str)),
+      fc.tuple(fc.hexaString(smallStringOptions), fc.boolean()).map((
+        [str, stay],
+      ) => new SplitCommand(str, stay)),
+    ];
+    fc.assert(
+      fc.property(
+        fc.commands(allCommands, { maxCommands: 512, size: "max" }),
         (cmds) => {
           function s() {
             return { model: new Map(), real: new PMap.Map() };


### PR DESCRIPTION
Added the `split` function to Map
- Removed the `length` field from `Map`
- Added `split`
- General code improvements